### PR TITLE
feat(network): add low-risk network policies

### DIFF
--- a/k8s/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/k8s/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -33,6 +33,35 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: cert-manager
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: cert-manager
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+          - target:
+              kind: Deployment
+              name: cert-manager-cainjector
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: cert-manager-cainjector
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     replicaCount: 2
     crds:

--- a/k8s/apps/cert-manager/network-policies/app/kustomization.yaml
+++ b/k8s/apps/cert-manager/network-policies/app/kustomization.yaml
@@ -1,10 +1,6 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
-components:
-  - ../../components/common
 resources:
-  - ./network-policies/ks.yaml
-  - ./cert-manager/ks.yaml
-  - ./trust-manager/ks.yaml
+  - vmagent-scrape.yaml

--- a/k8s/apps/cert-manager/network-policies/app/vmagent-scrape.yaml
+++ b/k8s/apps/cert-manager/network-policies/app/vmagent-scrape.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vmagent-scrape
+spec:
+  podSelector:
+    matchLabels:
+      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: victoria
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: http-metrics
+        - protocol: TCP
+          port: https
+        - protocol: TCP
+          port: prometheus
+        - protocol: TCP
+          port: hubble-metrics
+        - protocol: TCP
+          port: envoy-metrics
+        - protocol: TCP
+          port: tcp-9153

--- a/k8s/apps/cert-manager/network-policies/ks.yaml
+++ b/k8s/apps/cert-manager/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager-network-policies
+  namespace: cert-manager
+spec:
+  targetNamespace: cert-manager
+  path: ./k8s/apps/cert-manager/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/k8s/apps/default/audiobookshelf/app/kustomization.yaml
+++ b/k8s/apps/default/audiobookshelf/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/audiobookshelf/app/networkpolicy.yaml
+++ b/k8s/apps/default/audiobookshelf/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: audiobookshelf
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: audiobookshelf
+      app.kubernetes.io/instance: audiobookshelf
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: external
+      ports:
+        - protocol: TCP
+          port: http

--- a/k8s/apps/default/filebrowser/app/kustomization.yaml
+++ b/k8s/apps/default/filebrowser/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/filebrowser/app/networkpolicy.yaml
+++ b/k8s/apps/default/filebrowser/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: filebrowser
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: filebrowser
+      app.kubernetes.io/instance: filebrowser
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: internal
+      ports:
+        - protocol: TCP
+          port: http

--- a/k8s/apps/default/registry/ui/app/kustomization.yaml
+++ b/k8s/apps/default/registry/ui/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/registry/ui/app/networkpolicy.yaml
+++ b/k8s/apps/default/registry/ui/app/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: registry-ui
+spec:
+  podSelector:
+    matchLabels:
+      app: registry-ui
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: internal
+      ports:
+        - protocol: TCP
+          port: http

--- a/k8s/apps/default/thelounge/app/kustomization.yaml
+++ b/k8s/apps/default/thelounge/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - service.yaml
   - httproute.yaml
   - pvc.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/thelounge/app/networkpolicy.yaml
+++ b/k8s/apps/default/thelounge/app/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: thelounge
+spec:
+  podSelector:
+    matchLabels:
+      app: thelounge
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: internal
+      ports:
+        - protocol: TCP
+          port: web

--- a/k8s/apps/default/wizarr/app/kustomization.yaml
+++ b/k8s/apps/default/wizarr/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - httproute.yaml
   - deployment.yaml
   - service.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/wizarr/app/networkpolicy.yaml
+++ b/k8s/apps/default/wizarr/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wizarr
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wizarr
+      app.kubernetes.io/instance: wizarr
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: external
+      ports:
+        - protocol: TCP
+          port: web

--- a/k8s/apps/default/wrtag/app/kustomization.yaml
+++ b/k8s/apps/default/wrtag/app/kustomization.yaml
@@ -1,10 +1,13 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: wrtag
+labels:
+  - pairs:
+      app: wrtag
+    includeSelectors: false
 resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
   - externalsecret.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/default/wrtag/app/networkpolicy.yaml
+++ b/k8s/apps/default/wrtag/app/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wrtag
+spec:
+  podSelector:
+    matchLabels:
+      app: wrtag
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: internal
+      ports:
+        - protocol: TCP
+          port: web

--- a/k8s/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/k8s/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -36,6 +36,35 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: external-secrets
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: external-secrets
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+          - target:
+              kind: Deployment
+              name: external-secrets-cert-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: external-secrets-cert-controller
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     installCRDs: true
     image: &image

--- a/k8s/apps/external-secrets/kustomization.yaml
+++ b/k8s/apps/external-secrets/kustomization.yaml
@@ -5,5 +5,6 @@ namespace: external-secrets
 components:
   - ../../components/common
 resources:
+  - ./network-policies/ks.yaml
   - ./external-secrets/ks.yaml
   - ./onepassword/ks.yaml

--- a/k8s/apps/external-secrets/network-policies/app/kustomization.yaml
+++ b/k8s/apps/external-secrets/network-policies/app/kustomization.yaml
@@ -1,10 +1,6 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
-components:
-  - ../../components/common
 resources:
-  - ./network-policies/ks.yaml
-  - ./cert-manager/ks.yaml
-  - ./trust-manager/ks.yaml
+  - vmagent-scrape.yaml

--- a/k8s/apps/external-secrets/network-policies/app/vmagent-scrape.yaml
+++ b/k8s/apps/external-secrets/network-policies/app/vmagent-scrape.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vmagent-scrape
+spec:
+  podSelector:
+    matchLabels:
+      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: victoria
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: http-metrics
+        - protocol: TCP
+          port: https
+        - protocol: TCP
+          port: prometheus
+        - protocol: TCP
+          port: hubble-metrics
+        - protocol: TCP
+          port: envoy-metrics
+        - protocol: TCP
+          port: tcp-9153

--- a/k8s/apps/external-secrets/network-policies/ks.yaml
+++ b/k8s/apps/external-secrets/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets-network-policies
+  namespace: external-secrets
+spec:
+  targetNamespace: external-secrets
+  path: ./k8s/apps/external-secrets/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/k8s/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
+++ b/k8s/apps/monitoring/blackbox-exporter/app/helmrelease.yaml
@@ -31,6 +31,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: blackbox-exporter
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: blackbox-exporter
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: blackbox-exporter
     resources:

--- a/k8s/apps/monitoring/karma/app/kustomization.yaml
+++ b/k8s/apps/monitoring/karma/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/monitoring/karma/app/networkpolicy.yaml
+++ b/k8s/apps/monitoring/karma/app/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: karma
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: karma
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: envoy
+              app.kubernetes.io/component: proxy
+              gateway: internal
+      ports:
+        - protocol: TCP
+          port: http

--- a/k8s/apps/monitoring/kube-state-metrics/app/helmrelease.yaml
+++ b/k8s/apps/monitoring/kube-state-metrics/app/helmrelease.yaml
@@ -27,6 +27,22 @@ spec:
   dependsOn:
     - name: prometheus-operator-crds
       namespace: monitoring
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kube-state-metrics
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kube-state-metrics
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     metricLabelsAllowlist:
       - pods=[*]

--- a/k8s/apps/monitoring/kustomization.yaml
+++ b/k8s/apps/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 components:
   - ../../components/common
 resources:
+  - network-policies/ks.yaml
   - grafana/ks.yaml
   - vector/ks.yaml
   - karma/ks.yaml

--- a/k8s/apps/monitoring/network-policies/app/kustomization.yaml
+++ b/k8s/apps/monitoring/network-policies/app/kustomization.yaml
@@ -1,10 +1,6 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
-components:
-  - ../../components/common
 resources:
-  - ./network-policies/ks.yaml
-  - ./cert-manager/ks.yaml
-  - ./trust-manager/ks.yaml
+  - vmagent-scrape.yaml

--- a/k8s/apps/monitoring/network-policies/app/vmagent-scrape.yaml
+++ b/k8s/apps/monitoring/network-policies/app/vmagent-scrape.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vmagent-scrape
+spec:
+  podSelector:
+    matchLabels:
+      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: victoria
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: http-metrics
+        - protocol: TCP
+          port: https
+        - protocol: TCP
+          port: prometheus
+        - protocol: TCP
+          port: hubble-metrics
+        - protocol: TCP
+          port: envoy-metrics
+        - protocol: TCP
+          port: tcp-9153

--- a/k8s/apps/monitoring/network-policies/ks.yaml
+++ b/k8s/apps/monitoring/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring-network-policies
+  namespace: monitoring
+spec:
+  targetNamespace: monitoring
+  path: ./k8s/apps/monitoring/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/k8s/apps/monitoring/smartctl-exporter/app/helmrelease.yaml
+++ b/k8s/apps/monitoring/smartctl-exporter/app/helmrelease.yaml
@@ -30,6 +30,22 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: smartctl-exporter-0
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: smartctl-exporter-0
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: *app
     resources:

--- a/k8s/apps/monitoring/snmp-exporter/app/helmrelease.yaml
+++ b/k8s/apps/monitoring/snmp-exporter/app/helmrelease.yaml
@@ -31,6 +31,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: snmp-exporter
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: snmp-exporter
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: *app
     resources:

--- a/k8s/apps/network/cloudflared/app/deployment.yaml
+++ b/k8s/apps/network/cloudflared/app/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: *app
+        networking.cbannister.xyz/allow-vmagent-scrape: "true"
     spec:
       priorityClassName: cluster-p2
       volumes:

--- a/k8s/apps/network/external-dns/bind-crd/helmrelease.yaml
+++ b/k8s/apps/network/external-dns/bind-crd/helmrelease.yaml
@@ -16,6 +16,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: external-dns-bind-crd
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: external-dns-bind-crd
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: *app
     serviceAccount:

--- a/k8s/apps/network/external-dns/bind/helmrelease.yaml
+++ b/k8s/apps/network/external-dns/bind/helmrelease.yaml
@@ -31,6 +31,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: external-dns-bind
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: external-dns-bind
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: *app
     resources:

--- a/k8s/apps/network/external-dns/cloudflare/helmrelease.yaml
+++ b/k8s/apps/network/external-dns/cloudflare/helmrelease.yaml
@@ -24,6 +24,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: external-dns-cloudflare
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: external-dns-cloudflare
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     fullnameOverride: *app
     resources:

--- a/k8s/apps/network/kustomization.yaml
+++ b/k8s/apps/network/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: network
 components:
   - ../../components/common
 resources:
+  - network-policies/ks.yaml
   - external-dns/ks.yaml
   - cloudflared/ks.yaml
   - bind/ks.yaml

--- a/k8s/apps/network/network-policies/app/kustomization.yaml
+++ b/k8s/apps/network/network-policies/app/kustomization.yaml
@@ -1,10 +1,6 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
-components:
-  - ../../components/common
 resources:
-  - ./network-policies/ks.yaml
-  - ./cert-manager/ks.yaml
-  - ./trust-manager/ks.yaml
+  - vmagent-scrape.yaml

--- a/k8s/apps/network/network-policies/app/vmagent-scrape.yaml
+++ b/k8s/apps/network/network-policies/app/vmagent-scrape.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vmagent-scrape
+spec:
+  podSelector:
+    matchLabels:
+      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: victoria
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: http-metrics
+        - protocol: TCP
+          port: https
+        - protocol: TCP
+          port: prometheus
+        - protocol: TCP
+          port: hubble-metrics
+        - protocol: TCP
+          port: envoy-metrics
+        - protocol: TCP
+          port: tcp-9153

--- a/k8s/apps/network/network-policies/ks.yaml
+++ b/k8s/apps/network/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: network-network-policies
+  namespace: network
+spec:
+  targetNamespace: network
+  path: ./k8s/apps/network/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/k8s/apps/volsync-system/kustomization.yaml
+++ b/k8s/apps/volsync-system/kustomization.yaml
@@ -5,5 +5,6 @@ namespace: volsync-system
 components:
   - ../../components/common
 resources:
+  - ./network-policies/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./volsync/ks.yaml

--- a/k8s/apps/volsync-system/network-policies/app/kustomization.yaml
+++ b/k8s/apps/volsync-system/network-policies/app/kustomization.yaml
@@ -1,10 +1,6 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
-components:
-  - ../../components/common
 resources:
-  - ./network-policies/ks.yaml
-  - ./cert-manager/ks.yaml
-  - ./trust-manager/ks.yaml
+  - vmagent-scrape.yaml

--- a/k8s/apps/volsync-system/network-policies/app/vmagent-scrape.yaml
+++ b/k8s/apps/volsync-system/network-policies/app/vmagent-scrape.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vmagent-scrape
+spec:
+  podSelector:
+    matchLabels:
+      networking.cbannister.xyz/allow-vmagent-scrape: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: victoria
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: http-metrics
+        - protocol: TCP
+          port: https
+        - protocol: TCP
+          port: prometheus
+        - protocol: TCP
+          port: hubble-metrics
+        - protocol: TCP
+          port: envoy-metrics
+        - protocol: TCP
+          port: tcp-9153

--- a/k8s/apps/volsync-system/network-policies/ks.yaml
+++ b/k8s/apps/volsync-system/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: volsync-system-network-policies
+  namespace: volsync-system
+spec:
+  targetNamespace: volsync-system
+  path: ./k8s/apps/volsync-system/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/k8s/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
+++ b/k8s/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
@@ -24,6 +24,22 @@ spec:
     remediation:
       strategy: rollback
       retries: 3
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: snapshot-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: snapshot-controller
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      networking.cbannister.xyz/allow-vmagent-scrape: "true"
   values:
     controller:
       replicaCount: 2


### PR DESCRIPTION
Add namespace-local vmagent scrape policies and opt-in labels for selected metrics targets. Add ingress-only policies for simple Envoy-fronted apps based on Hubble validation.