### PR TITLE
fix(renovate): restore registry lookups

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -31,7 +31,8 @@ concurrency:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    # Renovate needs internal DNS and network access to resolve registry.cbannister.xyz.
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/k8s/apps/network/envoy-gateway/crds/helmrelease.yaml
+++ b/k8s/apps/network/envoy-gateway/crds/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: envoy-gateway-crds
 spec:
   interval: 10m
-  url: oci://mirror.ghcr.io/envoyproxy/gateway-crds-helm
+  url: oci://mirror.gcr.io/envoyproxy/gateway-crds-helm
   ref:
     tag: 1.6.0
   layerSelector:


### PR DESCRIPTION
## What changed

- Correct the Envoy Gateway CRD OCI registry from `mirror.ghcr.io` to `mirror.gcr.io`.
- Run Renovate on a Linux x64 self-hosted runner with access to the internal container registry.

## Why

The dependency dashboard reports two package lookup failures:

- `mirror.ghcr.io/envoyproxy/gateway-crds-helm` returns `no-result`. The chart is published on Docker Hub, and the inherited home-operations preset already aliases `mirror.gcr.io` to `docker.io`.
- Renovate cannot determine the digest for `registry.cbannister.xyz/wrtag:multi-disk-handling` because the GitHub-hosted runner cannot reach the registry exposed through the internal Gateway.

Moving the job onto the internal runner lets Renovate query the existing tag and digest directly. The deployment remains digest-pinned; this does not disable updates or weaken image immutability.

## Impact

After merge, the Renovate workflow requires a registered runner matching `self-hosted`, `linux`, and `x64`, with internal DNS and network access to `registry.cbannister.xyz`.

## Validation

- Compared the branch against `main`: only the Renovate workflow and Envoy Gateway CRD HelmRelease changed.
- Confirmed the inherited registry alias maps `mirror.gcr.io` to `docker.io`.
- Confirmed the wrtag image remains pinned to its existing SHA-256 digest.

Closes the package lookup warnings tracked in #280.
